### PR TITLE
fix(nem12): avoid retained parser state

### DIFF
--- a/src/AEMO.MDFF.Tests/NEM12/BasicTest.cs
+++ b/src/AEMO.MDFF.Tests/NEM12/BasicTest.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using AEMO.MDFF.Abstractions;
 using AEMO.MDFF.NEM12;
 using Xunit.Abstractions;
 
@@ -32,6 +34,32 @@ public class BasicTest
                     _testOutputHelper.WriteLine(intervalDataRecord.UpdateDateTime.ToLongTimeString());
                     break;
             }
+        }
+    }
+
+    [Fact]
+    public async Task ThrowsWhenIntervalDataRecordAppearsBeforeNmiDataDetailsRecord()
+    {
+        var nem12Reader = new Nem12Reader();
+        await using var fs = CreateStream("""
+                                          100,NEM12,200506081149,UNITEDDP,NEMMCO
+                                          300,20050301
+                                          900
+                                          """);
+
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(() => DrainAsync(nem12Reader.ReadAsync(fs, CancellationToken.None)));
+        Assert.Equal("Interval data record found before NMI data details record", ex.Message);
+    }
+
+    private static MemoryStream CreateStream(string content)
+    {
+        return new MemoryStream(Encoding.UTF8.GetBytes(content));
+    }
+
+    private static async Task DrainAsync(IAsyncEnumerable<IMdffRecord> records)
+    {
+        await foreach (var _ in records)
+        {
         }
     }
 }

--- a/src/AEMO.MDFF/NEM12/Nem12Reader.cs
+++ b/src/AEMO.MDFF/NEM12/Nem12Reader.cs
@@ -7,8 +7,6 @@ namespace AEMO.MDFF.NEM12;
 
 public class Nem12Reader() : IMdffReader
 {
-    private readonly Dictionary<string, int> _nmiIntervalLengths = new();
-
     public async IAsyncEnumerable<IMdffRecord> ReadAsync(Stream stream, [EnumeratorCancellation] CancellationToken ct)
     {
         using var sr = new StreamReader(stream);
@@ -20,7 +18,7 @@ public class Nem12Reader() : IMdffReader
         
         bool headerFound = false;
         bool endFound = false;
-        string currentNMI = null;
+        int? currentIntervalLength = null;
         
         while (await csv.ReadAsync(ct) && !endFound)
         {
@@ -38,14 +36,15 @@ public class Nem12Reader() : IMdffReader
                     if (!headerFound)
                         throw new InvalidDataException("Data record found before header");
                     var ddr = ParseNMIDataDetailsRecord(csv);
-                    currentNMI = ddr.NMI;
-                    _nmiIntervalLengths[currentNMI] = ddr.IntervalLength;
+                    currentIntervalLength = ddr.IntervalLength;
                     yield return ddr;
                     break;
                 case "300":
                     if (!headerFound)
                         throw new InvalidDataException("Data record found before header");
-                    var idr = ParseIntervalDataRecord(csv, currentNMI);
+                    if (currentIntervalLength is null)
+                        throw new InvalidDataException("Interval data record found before NMI data details record");
+                    var idr = ParseIntervalDataRecord(csv, currentIntervalLength.Value);
                     yield return idr;
                     break;
                 case "400":
@@ -103,17 +102,16 @@ public class Nem12Reader() : IMdffReader
         };
     }
     
-    private IntervalDataRecord ParseIntervalDataRecord(CsvDataReader csv, string currentNMI)
+    private IntervalDataRecord ParseIntervalDataRecord(CsvDataReader csv, int intervalLength)
     {
         var intervalDate = DateOnly.ParseExact(csv.GetString(1), "yyyyMMdd", CultureInfo.InvariantCulture);
-        int intervalLength = _nmiIntervalLengths[currentNMI];
         int expectedIntervals = 1440 / intervalLength; // 1440 minutes in a day
         var updateDateTime = DateTime.ParseExact(csv.GetString(2 + expectedIntervals + 3), "yyyyMMddHHmmss", CultureInfo.InvariantCulture);
 
-        var intervalValues = new List<decimal>();
+        var intervalValues = new decimal[expectedIntervals];
         for (int i = 2; i < expectedIntervals + 2; i++)
         {
-            intervalValues.Add(csv.GetDecimal(i));
+            intervalValues[i - 2] = csv.GetDecimal(i);
         }
 
         return new IntervalDataRecord


### PR DESCRIPTION
## Summary
- remove reader-level NEM12 interval-length state so parser instances do not retain per-file data
- validate that 300 interval records cannot appear before a 200 NMI details record
- use a fixed-size interval value array for bounded per-record allocation

## Tests
- DOTNET_ROLL_FORWARD=Major dotnet test src/AEMO.MDFF.sln --no-restore