### PR TITLE
chore(dotnet): target supported frameworks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,16 +9,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: [ '8.x' ]
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
           dotnet-quality: 'ga'
 
       - name: Build solution

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
           dotnet-quality: 'ga'
 
       - name: Restore dependencies

--- a/src/AEMO.MDFF.Tests/AEMO.MDFF.Tests.csproj
+++ b/src/AEMO.MDFF.Tests/AEMO.MDFF.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/AEMO.MDFF/AEMO.MDFF.csproj
+++ b/src/AEMO.MDFF/AEMO.MDFF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary
- multi-target the library and tests for net8.0, net9.0, and net10.0
- install all supported SDK majors in build and publish workflows

## Notes
- Microsoft currently lists .NET 8, .NET 9, and .NET 10 as supported major versions: https://dotnet.microsoft.com/en-us/platform/support/policy