### PR TITLE
fix(nem12): model optional fields

### DIFF
--- a/src/AEMO.MDFF.Tests/NEM12/BasicTest.cs
+++ b/src/AEMO.MDFF.Tests/NEM12/BasicTest.cs
@@ -73,6 +73,46 @@ public class BasicTest
         Assert.Null(nmiDataDetails.NextScheduledReadDate);
     }
 
+    [Fact]
+    public async Task ParsesIntervalMetadataAndRelatedRecords()
+    {
+        var nem12Reader = new Nem12Reader();
+        var values = string.Join(",", Enumerable.Repeat("0", 48));
+        await using var fs = CreateStream($"""
+                                          100,NEM12,200506081149,UNITEDDP,NEMMCO
+                                          200,NEM1201009,E1E2,1,E1,N1,01009,kWh,30,20050610
+                                          300,20050301,{values},A,79,Power outage,20050310121004,20050310182204
+                                          400,1,48,A,79,Power outage
+                                          500,O,S01009,20050310121004,001123.5
+                                          900
+                                          """);
+
+        var records = new List<IMdffRecord>();
+        await foreach (var record in nem12Reader.ReadAsync(fs, CancellationToken.None))
+        {
+            records.Add(record);
+        }
+
+        var intervalData = Assert.IsType<IntervalDataRecord>(records[2]);
+        Assert.Equal("A", intervalData.QualityMethod);
+        Assert.Equal("79", intervalData.ReasonCode);
+        Assert.Equal("Power outage", intervalData.ReasonDescription);
+        Assert.Equal(new DateTime(2005, 03, 10, 12, 10, 04), intervalData.UpdateDateTime);
+        Assert.Equal(new DateTime(2005, 03, 10, 18, 22, 04), intervalData.MSATSLoadDateTime);
+
+        var intervalEvent = Assert.IsType<IntervalEventRecord>(records[3]);
+        Assert.Equal(1, intervalEvent.StartInterval);
+        Assert.Equal(48, intervalEvent.EndInterval);
+        Assert.Equal("A", intervalEvent.QualityMethod);
+        Assert.Equal("79", intervalEvent.ReasonCode);
+
+        var b2bDetails = Assert.IsType<B2BDetailsRecord>(records[4]);
+        Assert.Equal("O", b2bDetails.TransCode);
+        Assert.Equal("S01009", b2bDetails.RetServiceOrder);
+        Assert.Equal(new DateTime(2005, 03, 10, 12, 10, 04), b2bDetails.ReadDateTime);
+        Assert.Equal("001123.5", b2bDetails.IndexRead);
+    }
+
     private static MemoryStream CreateStream(string content)
     {
         return new MemoryStream(Encoding.UTF8.GetBytes(content));

--- a/src/AEMO.MDFF.Tests/NEM12/BasicTest.cs
+++ b/src/AEMO.MDFF.Tests/NEM12/BasicTest.cs
@@ -27,11 +27,11 @@ public class BasicTest
                     Assert.Equal(100.ToString(), vh);
                     break;
                 case NMIDataDetailsRecord { NextScheduledReadDate: var nsrd }:
-                    _testOutputHelper.WriteLine(nsrd.ToLongDateString());
+                    _testOutputHelper.WriteLine(nsrd?.ToLongDateString());
                     break;
                 case IntervalDataRecord intervalDataRecord:
                     _testOutputHelper.WriteLine(intervalDataRecord.IntervalValues.ToString());
-                    _testOutputHelper.WriteLine(intervalDataRecord.UpdateDateTime.ToLongTimeString());
+                    _testOutputHelper.WriteLine(intervalDataRecord.UpdateDateTime?.ToLongTimeString());
                     break;
             }
         }
@@ -49,6 +49,28 @@ public class BasicTest
 
         var ex = await Assert.ThrowsAsync<InvalidDataException>(() => DrainAsync(nem12Reader.ReadAsync(fs, CancellationToken.None)));
         Assert.Equal("Interval data record found before NMI data details record", ex.Message);
+    }
+
+    [Fact]
+    public async Task ParsesOptionalNmiFieldsAsNull()
+    {
+        var nem12Reader = new Nem12Reader();
+        await using var fs = CreateStream($"""
+                                          100,NEM12,200506081149,UNITEDDP,NEMMCO
+                                          200,NEM1201009,E1E2,,E1,,01009,kWh,30,
+                                          900
+                                          """);
+
+        var records = new List<IMdffRecord>();
+        await foreach (var record in nem12Reader.ReadAsync(fs, CancellationToken.None))
+        {
+            records.Add(record);
+        }
+
+        var nmiDataDetails = Assert.IsType<NMIDataDetailsRecord>(records[1]);
+        Assert.Null(nmiDataDetails.RegisterId);
+        Assert.Null(nmiDataDetails.MDMDataStreamIdentifier);
+        Assert.Null(nmiDataDetails.NextScheduledReadDate);
     }
 
     private static MemoryStream CreateStream(string content)

--- a/src/AEMO.MDFF/HeaderRecord.cs
+++ b/src/AEMO.MDFF/HeaderRecord.cs
@@ -5,8 +5,8 @@ namespace AEMO.MDFF;
 public sealed class HeaderRecord : IMdffRecord
 {
     public string RecordIndicator => "100";
-    public string VersionHeader { get; set; }
+    public string VersionHeader { get; set; } = string.Empty;
     public DateTime DateTime { get; set; }
-    public string FromParticipant { get; set; }
-    public string ToParticipant { get; set; }
+    public string FromParticipant { get; set; } = string.Empty;
+    public string ToParticipant { get; set; } = string.Empty;
 }

--- a/src/AEMO.MDFF/NEM12/B2BDetailsRecord.cs
+++ b/src/AEMO.MDFF/NEM12/B2BDetailsRecord.cs
@@ -1,0 +1,12 @@
+using AEMO.MDFF.Abstractions;
+
+namespace AEMO.MDFF.NEM12;
+
+public sealed class B2BDetailsRecord : IMdffRecord
+{
+    public string RecordIndicator => "500";
+    public string TransCode { get; set; } = string.Empty;
+    public string? RetServiceOrder { get; set; }
+    public DateTime? ReadDateTime { get; set; }
+    public string? IndexRead { get; set; }
+}

--- a/src/AEMO.MDFF/NEM12/IntervalDataRecord.cs
+++ b/src/AEMO.MDFF/NEM12/IntervalDataRecord.cs
@@ -6,10 +6,10 @@ public sealed class IntervalDataRecord : IMdffRecord
 {
     public string RecordIndicator => "300";
     public DateOnly IntervalDate { get; set; }
-    public IReadOnlyCollection<decimal> IntervalValues { get; set; }
-    public string QualityMethod { get; set; }
-    public string ReasonCode { get; set; }
-    public string ReasonDescription { get; set; }
-    public DateTime UpdateDateTime { get; set; }
-    public DateTime MSATSLoadDateTime { get; set; }
+    public IReadOnlyCollection<decimal> IntervalValues { get; set; } = Array.Empty<decimal>();
+    public string QualityMethod { get; set; } = string.Empty;
+    public string? ReasonCode { get; set; }
+    public string? ReasonDescription { get; set; }
+    public DateTime? UpdateDateTime { get; set; }
+    public DateTime? MSATSLoadDateTime { get; set; }
 }

--- a/src/AEMO.MDFF/NEM12/IntervalEventRecord.cs
+++ b/src/AEMO.MDFF/NEM12/IntervalEventRecord.cs
@@ -1,0 +1,13 @@
+using AEMO.MDFF.Abstractions;
+
+namespace AEMO.MDFF.NEM12;
+
+public sealed class IntervalEventRecord : IMdffRecord
+{
+    public string RecordIndicator => "400";
+    public int StartInterval { get; set; }
+    public int EndInterval { get; set; }
+    public string QualityMethod { get; set; } = string.Empty;
+    public string? ReasonCode { get; set; }
+    public string? ReasonDescription { get; set; }
+}

--- a/src/AEMO.MDFF/NEM12/NMIDataDetailsRecord.cs
+++ b/src/AEMO.MDFF/NEM12/NMIDataDetailsRecord.cs
@@ -5,13 +5,13 @@ namespace AEMO.MDFF.NEM12;
 public sealed class NMIDataDetailsRecord : IMdffRecord
 {
     public string RecordIndicator => "200";
-    public required string NMI { get; set; }
-    public string NMIConfiguration { get; set; }
-    public string RegisterId { get; set; }
-    public string NMISuffix { get; set; }
-    public string MDMDataStreamIdentifier { get; set; }
-    public string MeterSerialNumber { get; set; }
-    public string UOM { get; set; }
+    public string NMI { get; set; } = string.Empty;
+    public string NMIConfiguration { get; set; } = string.Empty;
+    public string? RegisterId { get; set; }
+    public string NMISuffix { get; set; } = string.Empty;
+    public string? MDMDataStreamIdentifier { get; set; }
+    public string? MeterSerialNumber { get; set; }
+    public string UOM { get; set; } = string.Empty;
     public int IntervalLength { get; set; }
-    public DateOnly NextScheduledReadDate { get; set; }
+    public DateOnly? NextScheduledReadDate { get; set; }
 }

--- a/src/AEMO.MDFF/NEM12/Nem12Reader.cs
+++ b/src/AEMO.MDFF/NEM12/Nem12Reader.cs
@@ -50,10 +50,14 @@ public class Nem12Reader() : IMdffReader
                 case "400":
                     if (!headerFound)
                         throw new InvalidDataException("Data record found before header");
+                    var ier = ParseIntervalEventRecord(csv);
+                    yield return ier;
                     break;
                 case "500":
                     if (!headerFound)
                         throw new InvalidDataException("Data record found before header");
+                    var b2b = ParseB2BDetailsRecord(csv);
+                    yield return b2b;
                     break;
                 case "900":
                     var er = new EndRecord();
@@ -103,7 +107,11 @@ public class Nem12Reader() : IMdffReader
     {
         var intervalDate = DateOnly.ParseExact(csv.GetString(1), "yyyyMMdd", CultureInfo.InvariantCulture);
         int expectedIntervals = 1440 / intervalLength; // 1440 minutes in a day
-        var updateDateTime = DateTime.ParseExact(csv.GetString(2 + expectedIntervals + 3), "yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+        int qualityMethodIndex = 2 + expectedIntervals;
+        int reasonCodeIndex = qualityMethodIndex + 1;
+        int reasonDescriptionIndex = qualityMethodIndex + 2;
+        int updateDateTimeIndex = qualityMethodIndex + 3;
+        int msatsLoadDateTimeIndex = qualityMethodIndex + 4;
 
         var intervalValues = new decimal[expectedIntervals];
         for (int i = 2; i < expectedIntervals + 2; i++)
@@ -115,7 +123,34 @@ public class Nem12Reader() : IMdffReader
         {
             IntervalDate = intervalDate,
             IntervalValues = intervalValues,
-            UpdateDateTime = updateDateTime,
+            QualityMethod = csv.GetString(qualityMethodIndex),
+            ReasonCode = GetOptionalString(csv, reasonCodeIndex),
+            ReasonDescription = GetOptionalString(csv, reasonDescriptionIndex),
+            UpdateDateTime = ParseOptionalDateTime(csv, updateDateTimeIndex),
+            MSATSLoadDateTime = ParseOptionalDateTime(csv, msatsLoadDateTimeIndex),
+        };
+    }
+
+    private IntervalEventRecord ParseIntervalEventRecord(CsvDataReader csv)
+    {
+        return new IntervalEventRecord
+        {
+            StartInterval = csv.GetInt32(1),
+            EndInterval = csv.GetInt32(2),
+            QualityMethod = csv.GetString(3),
+            ReasonCode = GetOptionalString(csv, 4),
+            ReasonDescription = GetOptionalString(csv, 5),
+        };
+    }
+
+    private B2BDetailsRecord ParseB2BDetailsRecord(CsvDataReader csv)
+    {
+        return new B2BDetailsRecord
+        {
+            TransCode = csv.GetString(1),
+            RetServiceOrder = GetOptionalString(csv, 2),
+            ReadDateTime = ParseOptionalDateTime(csv, 3),
+            IndexRead = GetOptionalString(csv, 4),
         };
     }
     private static DateOnly? ParseOptionalDate(CsvDataReader csv, int index)
@@ -124,6 +159,14 @@ public class Nem12Reader() : IMdffReader
         return value is null
             ? null
             : DateOnly.ParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture);
+    }
+
+    private static DateTime? ParseOptionalDateTime(CsvDataReader csv, int index)
+    {
+        var value = GetOptionalString(csv, index);
+        return value is null
+            ? null
+            : DateTime.ParseExact(value, "yyyyMMddHHmmss", CultureInfo.InvariantCulture);
     }
 
     private static string? GetOptionalString(CsvDataReader csv, int index)

--- a/src/AEMO.MDFF/NEM12/Nem12Reader.cs
+++ b/src/AEMO.MDFF/NEM12/Nem12Reader.cs
@@ -85,20 +85,17 @@ public class Nem12Reader() : IMdffReader
     }
     private NMIDataDetailsRecord ParseNMIDataDetailsRecord(CsvDataReader csv)
     {
-        var dateString = csv.GetString(9);
-        var date = DateOnly.ParseExact(dateString, "yyyyMMdd", CultureInfo.InvariantCulture);
-
         return new NMIDataDetailsRecord
         {
             NMI = csv.GetString(1),
             NMIConfiguration = csv.GetString(2),
-            RegisterId = csv.GetString(3),
+            RegisterId = GetOptionalString(csv, 3),
             NMISuffix = csv.GetString(4),
-            MDMDataStreamIdentifier = csv.GetString(5),
-            MeterSerialNumber = csv.GetString(6),
+            MDMDataStreamIdentifier = GetOptionalString(csv, 5),
+            MeterSerialNumber = GetOptionalString(csv, 6),
             UOM = csv.GetString(7),
             IntervalLength = csv.GetInt32(8),
-            NextScheduledReadDate = date
+            NextScheduledReadDate = ParseOptionalDate(csv, 9)
         };
     }
     
@@ -120,5 +117,18 @@ public class Nem12Reader() : IMdffReader
             IntervalValues = intervalValues,
             UpdateDateTime = updateDateTime,
         };
+    }
+    private static DateOnly? ParseOptionalDate(CsvDataReader csv, int index)
+    {
+        var value = GetOptionalString(csv, index);
+        return value is null
+            ? null
+            : DateOnly.ParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture);
+    }
+
+    private static string? GetOptionalString(CsvDataReader csv, int index)
+    {
+        var value = csv.GetString(index);
+        return string.IsNullOrEmpty(value) ? null : value;
     }
 }


### PR DESCRIPTION
## Summary
- initialize non-null record properties to satisfy nullable analysis
- model MDFF optional fields as nullable, including NSRD and interval metadata
- parse empty optional date/string fields as null

## Tests
- DOTNET_ROLL_FORWARD=Major dotnet test src/AEMO.MDFF.sln