### PR TITLE
chore(actions): update workflow actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.x

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.x


### PR DESCRIPTION
## Summary
- update actions/checkout from v4 to v6
- update actions/setup-dotnet from v4 to v5
- moves workflows to current Node 24-compatible action majors

## References
- actions/checkout latest: https://github.com/actions/checkout
- actions/setup-dotnet latest: https://github.com/actions/setup-dotnet/releases

## Tests
- workflow-only change; not run locally