### PR TITLE
fix(nem12): parse related record metadata

### DIFF
--- a/src/AEMO.MDFF.Tests/NEM12/BasicTest.cs
+++ b/src/AEMO.MDFF.Tests/NEM12/BasicTest.cs
@@ -73,6 +73,46 @@ public class BasicTest
         Assert.Null(nmiDataDetails.NextScheduledReadDate);
     }
 
+    [Fact]
+    public async Task ParsesIntervalMetadataAndRelatedRecords()
+    {
+        var nem12Reader = new Nem12Reader();
+        var values = string.Join(",", Enumerable.Repeat("0", 48));
+        await using var fs = CreateStream($"""
+                                          100,NEM12,200506081149,UNITEDDP,NEMMCO
+                                          200,NEM1201009,E1E2,1,E1,N1,01009,kWh,30,20050610
+                                          300,20050301,{values},A,79,Power outage,20050310121004,20050310182204
+                                          400,1,48,A,79,Power outage
+                                          500,O,S01009,20050310121004,001123.5
+                                          900
+                                          """);
+
+        var records = new List<IMdffRecord>();
+        await foreach (var record in nem12Reader.ReadAsync(fs, CancellationToken.None))
+        {
+            records.Add(record);
+        }
+
+        var intervalData = Assert.IsType<IntervalDataRecord>(records[2]);
+        Assert.Equal("A", intervalData.QualityMethod);
+        Assert.Equal("79", intervalData.ReasonCode);
+        Assert.Equal("Power outage", intervalData.ReasonDescription);
+        Assert.Equal(new DateTime(2005, 03, 10, 12, 10, 04), intervalData.UpdateDateTime);
+        Assert.Equal(new DateTime(2005, 03, 10, 18, 22, 04), intervalData.MSATSLoadDateTime);
+
+        var intervalEvent = Assert.IsType<IntervalEventRecord>(records[3]);
+        Assert.Equal(1, intervalEvent.StartInterval);
+        Assert.Equal(48, intervalEvent.EndInterval);
+        Assert.Equal("A", intervalEvent.QualityMethod);
+        Assert.Equal("79", intervalEvent.ReasonCode);
+
+        var b2bDetails = Assert.IsType<B2BDetailsRecord>(records[4]);
+        Assert.Equal("O", b2bDetails.TransCode);
+        Assert.Equal("S01009", b2bDetails.RetServiceOrder);
+        Assert.Equal(new DateTime(2005, 03, 10, 12, 10, 04), b2bDetails.ReadDateTime);
+        Assert.Equal("001123.5", b2bDetails.IndexRead);
+    }
+
     private static MemoryStream CreateStream(string content)
     {
         return new MemoryStream(Encoding.UTF8.GetBytes(content));

--- a/src/AEMO.MDFF/NEM12/B2BDetailsRecord.cs
+++ b/src/AEMO.MDFF/NEM12/B2BDetailsRecord.cs
@@ -1,0 +1,12 @@
+using AEMO.MDFF.Abstractions;
+
+namespace AEMO.MDFF.NEM12;
+
+public sealed class B2BDetailsRecord : IMdffRecord
+{
+    public string RecordIndicator => "500";
+    public string TransCode { get; set; } = string.Empty;
+    public string? RetServiceOrder { get; set; }
+    public DateTime? ReadDateTime { get; set; }
+    public string? IndexRead { get; set; }
+}

--- a/src/AEMO.MDFF/NEM12/IntervalEventRecord.cs
+++ b/src/AEMO.MDFF/NEM12/IntervalEventRecord.cs
@@ -1,0 +1,13 @@
+using AEMO.MDFF.Abstractions;
+
+namespace AEMO.MDFF.NEM12;
+
+public sealed class IntervalEventRecord : IMdffRecord
+{
+    public string RecordIndicator => "400";
+    public int StartInterval { get; set; }
+    public int EndInterval { get; set; }
+    public string QualityMethod { get; set; } = string.Empty;
+    public string? ReasonCode { get; set; }
+    public string? ReasonDescription { get; set; }
+}

--- a/src/AEMO.MDFF/NEM12/Nem12Reader.cs
+++ b/src/AEMO.MDFF/NEM12/Nem12Reader.cs
@@ -50,10 +50,14 @@ public class Nem12Reader() : IMdffReader
                 case "400":
                     if (!headerFound)
                         throw new InvalidDataException("Data record found before header");
+                    var ier = ParseIntervalEventRecord(csv);
+                    yield return ier;
                     break;
                 case "500":
                     if (!headerFound)
                         throw new InvalidDataException("Data record found before header");
+                    var b2b = ParseB2BDetailsRecord(csv);
+                    yield return b2b;
                     break;
                 case "900":
                     var er = new EndRecord();
@@ -103,7 +107,11 @@ public class Nem12Reader() : IMdffReader
     {
         var intervalDate = DateOnly.ParseExact(csv.GetString(1), "yyyyMMdd", CultureInfo.InvariantCulture);
         int expectedIntervals = 1440 / intervalLength; // 1440 minutes in a day
-        var updateDateTime = DateTime.ParseExact(csv.GetString(2 + expectedIntervals + 3), "yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+        int qualityMethodIndex = 2 + expectedIntervals;
+        int reasonCodeIndex = qualityMethodIndex + 1;
+        int reasonDescriptionIndex = qualityMethodIndex + 2;
+        int updateDateTimeIndex = qualityMethodIndex + 3;
+        int msatsLoadDateTimeIndex = qualityMethodIndex + 4;
 
         var intervalValues = new decimal[expectedIntervals];
         for (int i = 2; i < expectedIntervals + 2; i++)
@@ -115,7 +123,34 @@ public class Nem12Reader() : IMdffReader
         {
             IntervalDate = intervalDate,
             IntervalValues = intervalValues,
-            UpdateDateTime = updateDateTime,
+            QualityMethod = csv.GetString(qualityMethodIndex),
+            ReasonCode = GetOptionalString(csv, reasonCodeIndex),
+            ReasonDescription = GetOptionalString(csv, reasonDescriptionIndex),
+            UpdateDateTime = ParseOptionalDateTime(csv, updateDateTimeIndex),
+            MSATSLoadDateTime = ParseOptionalDateTime(csv, msatsLoadDateTimeIndex),
+        };
+    }
+
+    private IntervalEventRecord ParseIntervalEventRecord(CsvDataReader csv)
+    {
+        return new IntervalEventRecord
+        {
+            StartInterval = csv.GetInt32(1),
+            EndInterval = csv.GetInt32(2),
+            QualityMethod = csv.GetString(3),
+            ReasonCode = GetOptionalString(csv, 4),
+            ReasonDescription = GetOptionalString(csv, 5),
+        };
+    }
+
+    private B2BDetailsRecord ParseB2BDetailsRecord(CsvDataReader csv)
+    {
+        return new B2BDetailsRecord
+        {
+            TransCode = csv.GetString(1),
+            RetServiceOrder = GetOptionalString(csv, 2),
+            ReadDateTime = ParseOptionalDateTime(csv, 3),
+            IndexRead = GetOptionalString(csv, 4),
         };
     }
     private static DateOnly? ParseOptionalDate(CsvDataReader csv, int index)
@@ -124,6 +159,14 @@ public class Nem12Reader() : IMdffReader
         return value is null
             ? null
             : DateOnly.ParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture);
+    }
+
+    private static DateTime? ParseOptionalDateTime(CsvDataReader csv, int index)
+    {
+        var value = GetOptionalString(csv, index);
+        return value is null
+            ? null
+            : DateTime.ParseExact(value, "yyyyMMddHHmmss", CultureInfo.InvariantCulture);
     }
 
     private static string? GetOptionalString(CsvDataReader csv, int index)


### PR DESCRIPTION
## Summary
- populate NEM12 300 record quality, reason, update, and MSATS load metadata
- add IntervalEventRecord for 400 records
- add B2BDetailsRecord for 500 records

## Stack
- stacked on #18 because this uses the nullable field shapes from that PR

## Tests
- DOTNET_ROLL_FORWARD=Major dotnet test src/AEMO.MDFF.sln