### PR TITLE
feat(nem13): implement reader

### DIFF
--- a/src/AEMO.MDFF.Tests/NEM13/BasicTest.cs
+++ b/src/AEMO.MDFF.Tests/NEM13/BasicTest.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using AEMO.MDFF.Abstractions;
+using AEMO.MDFF.NEM13;
+
+namespace AEMO.MDFF.Tests.NEM13;
+
+public class BasicTest
+{
+    [Fact]
+    public async Task ParsesNem13Records()
+    {
+        var nem13Reader = new Nem13Reader();
+        await using var fs = CreateStream("""
+                                          100,NEM13,200506081149,UNITEDDP,NEMMCO
+                                          250,1234567890,1141,01,11,11,METSER66,E,000021.2,20031001103230,A,,,000534.5,20040201100030,E64,77,,343.5,kWh,20040509,20040202125010,20040203000130
+                                          550,N,,A,S01009
+                                          900
+                                          """);
+
+        var records = new List<IMdffRecord>();
+        await foreach (var record in nem13Reader.ReadAsync(fs, CancellationToken.None))
+        {
+            records.Add(record);
+        }
+
+        var header = Assert.IsType<HeaderRecord>(records[0]);
+        Assert.Equal("NEM13", header.VersionHeader);
+
+        var accumulationData = Assert.IsType<AccumulationMeterDataRecord>(records[1]);
+        Assert.Equal("1234567890", accumulationData.NMI);
+        Assert.Equal("000021.2", accumulationData.PreviousRegisterRead);
+        Assert.Equal(new DateTime(2003, 10, 01, 10, 32, 30), accumulationData.PreviousRegisterReadDateTime);
+        Assert.Equal("000534.5", accumulationData.CurrentRegisterRead);
+        Assert.Equal(new DateTime(2004, 02, 01, 10, 00, 30), accumulationData.CurrentRegisterReadDateTime);
+        Assert.Equal(343.5m, accumulationData.Quantity);
+        Assert.Equal(new DateOnly(2004, 05, 09), accumulationData.NextScheduledReadDate);
+        Assert.Equal(new DateTime(2004, 02, 02, 12, 50, 10), accumulationData.UpdateDateTime);
+        Assert.Equal(new DateTime(2004, 02, 03, 00, 01, 30), accumulationData.MSATSLoadDateTime);
+
+        var b2bDetails = Assert.IsType<B2BDetailsRecord>(records[2]);
+        Assert.Equal("N", b2bDetails.PreviousTransCode);
+        Assert.Null(b2bDetails.PreviousRetServiceOrder);
+        Assert.Equal("A", b2bDetails.CurrentTransCode);
+        Assert.Equal("S01009", b2bDetails.CurrentRetServiceOrder);
+
+        Assert.IsType<EndRecord>(records[3]);
+    }
+
+    [Fact]
+    public async Task ThrowsWhenDataRecordAppearsBeforeHeader()
+    {
+        var nem13Reader = new Nem13Reader();
+        await using var fs = CreateStream("""
+                                          250,1234567890,1141,01,11,11,METSER66,E,000021.2,20031001103230,A,,,000534.5,20040201100030,E64,77,,343.5,kWh,20040509,20040202125010,20040203000130
+                                          900
+                                          """);
+
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(() => DrainAsync(nem13Reader.ReadAsync(fs, CancellationToken.None)));
+        Assert.Equal("Data record found before header", ex.Message);
+    }
+
+    private static MemoryStream CreateStream(string content)
+    {
+        return new MemoryStream(Encoding.UTF8.GetBytes(content));
+    }
+
+    private static async Task DrainAsync(IAsyncEnumerable<IMdffRecord> records)
+    {
+        await foreach (var _ in records)
+        {
+        }
+    }
+}

--- a/src/AEMO.MDFF/NEM13/AccumulationMeterDataRecord.cs
+++ b/src/AEMO.MDFF/NEM13/AccumulationMeterDataRecord.cs
@@ -1,0 +1,30 @@
+using AEMO.MDFF.Abstractions;
+
+namespace AEMO.MDFF.NEM13;
+
+public sealed class AccumulationMeterDataRecord : IMdffRecord
+{
+    public string RecordIndicator => "250";
+    public string NMI { get; set; } = string.Empty;
+    public string NMIConfiguration { get; set; } = string.Empty;
+    public string RegisterId { get; set; } = string.Empty;
+    public string NMISuffix { get; set; } = string.Empty;
+    public string? MDMDataStreamIdentifier { get; set; }
+    public string MeterSerialNumber { get; set; } = string.Empty;
+    public string DirectionIndicator { get; set; } = string.Empty;
+    public string PreviousRegisterRead { get; set; } = string.Empty;
+    public DateTime PreviousRegisterReadDateTime { get; set; }
+    public string PreviousQualityMethod { get; set; } = string.Empty;
+    public string? PreviousReasonCode { get; set; }
+    public string? PreviousReasonDescription { get; set; }
+    public string CurrentRegisterRead { get; set; } = string.Empty;
+    public DateTime CurrentRegisterReadDateTime { get; set; }
+    public string CurrentQualityMethod { get; set; } = string.Empty;
+    public string? CurrentReasonCode { get; set; }
+    public string? CurrentReasonDescription { get; set; }
+    public decimal Quantity { get; set; }
+    public string UOM { get; set; } = string.Empty;
+    public DateOnly? NextScheduledReadDate { get; set; }
+    public DateTime UpdateDateTime { get; set; }
+    public DateTime? MSATSLoadDateTime { get; set; }
+}

--- a/src/AEMO.MDFF/NEM13/B2BDetailsRecord.cs
+++ b/src/AEMO.MDFF/NEM13/B2BDetailsRecord.cs
@@ -1,0 +1,12 @@
+using AEMO.MDFF.Abstractions;
+
+namespace AEMO.MDFF.NEM13;
+
+public sealed class B2BDetailsRecord : IMdffRecord
+{
+    public string RecordIndicator => "550";
+    public string PreviousTransCode { get; set; } = string.Empty;
+    public string? PreviousRetServiceOrder { get; set; }
+    public string CurrentTransCode { get; set; } = string.Empty;
+    public string? CurrentRetServiceOrder { get; set; }
+}

--- a/src/AEMO.MDFF/NEM13/Nem13Reader.cs
+++ b/src/AEMO.MDFF/NEM13/Nem13Reader.cs
@@ -1,11 +1,145 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
 using AEMO.MDFF.Abstractions;
+using Sylvan.Data.Csv;
 
 namespace AEMO.MDFF.NEM13;
 
 public class Nem13Reader : IMdffReader
 {
-    public IAsyncEnumerable<IMdffRecord> ReadAsync(Stream stream, CancellationToken ct)
+    public async IAsyncEnumerable<IMdffRecord> ReadAsync(Stream stream, [EnumeratorCancellation] CancellationToken ct)
     {
-        throw new NotImplementedException();
+        using var sr = new StreamReader(stream);
+        await using var csv = await CsvDataReader.CreateAsync(sr,
+            new CsvDataReaderOptions()
+            {
+                HasHeaders = false,
+            }, ct);
+
+        bool headerFound = false;
+        bool endFound = false;
+
+        while (await csv.ReadAsync(ct) && !endFound)
+        {
+            var recordIndicator = csv.GetString(0);
+            switch (recordIndicator)
+            {
+                case "100":
+                    if (headerFound)
+                        throw new InvalidDataException("Multiple header records found");
+                    var hr = ParseHeaderRecord(csv);
+                    headerFound = true;
+                    yield return hr;
+                    break;
+                case "250":
+                    if (!headerFound)
+                        throw new InvalidDataException("Data record found before header");
+                    var amdr = ParseAccumulationMeterDataRecord(csv);
+                    yield return amdr;
+                    break;
+                case "550":
+                    if (!headerFound)
+                        throw new InvalidDataException("Data record found before header");
+                    var b2b = ParseB2BDetailsRecord(csv);
+                    yield return b2b;
+                    break;
+                case "900":
+                    var er = new EndRecord();
+                    endFound = true;
+                    yield return er;
+                    break;
+                default:
+                    throw new InvalidDataException($"Unsupported record indicator: {recordIndicator}");
+            }
+        }
+
+        if (!headerFound)
+            throw new InvalidDataException("No header record found");
+        if (!endFound)
+            throw new InvalidDataException("No end record found");
+    }
+
+    private HeaderRecord ParseHeaderRecord(CsvDataReader csv)
+    {
+        var dateTimeString = csv.GetString(2);
+        var dateTime = DateTime.ParseExact(dateTimeString, "yyyyMMddHHmm", CultureInfo.InvariantCulture);
+        var versionHeader = csv.GetString(1);
+        if (!string.Equals(versionHeader, "NEM13", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidDataException($"Unsupported NEM13 version header: {versionHeader}");
+
+        return new HeaderRecord()
+        {
+            VersionHeader = versionHeader,
+            DateTime = dateTime,
+            FromParticipant = csv.GetString(3),
+            ToParticipant = csv.GetString(4)
+        };
+    }
+
+    private AccumulationMeterDataRecord ParseAccumulationMeterDataRecord(CsvDataReader csv)
+    {
+        return new AccumulationMeterDataRecord
+        {
+            NMI = csv.GetString(1),
+            NMIConfiguration = csv.GetString(2),
+            RegisterId = csv.GetString(3),
+            NMISuffix = csv.GetString(4),
+            MDMDataStreamIdentifier = GetOptionalString(csv, 5),
+            MeterSerialNumber = csv.GetString(6),
+            DirectionIndicator = csv.GetString(7),
+            PreviousRegisterRead = csv.GetString(8),
+            PreviousRegisterReadDateTime = ParseDateTime(csv, 9),
+            PreviousQualityMethod = csv.GetString(10),
+            PreviousReasonCode = GetOptionalString(csv, 11),
+            PreviousReasonDescription = GetOptionalString(csv, 12),
+            CurrentRegisterRead = csv.GetString(13),
+            CurrentRegisterReadDateTime = ParseDateTime(csv, 14),
+            CurrentQualityMethod = csv.GetString(15),
+            CurrentReasonCode = GetOptionalString(csv, 16),
+            CurrentReasonDescription = GetOptionalString(csv, 17),
+            Quantity = csv.GetDecimal(18),
+            UOM = csv.GetString(19),
+            NextScheduledReadDate = ParseOptionalDate(csv, 20),
+            UpdateDateTime = ParseDateTime(csv, 21),
+            MSATSLoadDateTime = ParseOptionalDateTime(csv, 22),
+        };
+    }
+
+    private B2BDetailsRecord ParseB2BDetailsRecord(CsvDataReader csv)
+    {
+        return new B2BDetailsRecord
+        {
+            PreviousTransCode = csv.GetString(1),
+            PreviousRetServiceOrder = GetOptionalString(csv, 2),
+            CurrentTransCode = csv.GetString(3),
+            CurrentRetServiceOrder = GetOptionalString(csv, 4),
+        };
+    }
+
+    private static DateTime ParseDateTime(CsvDataReader csv, int index)
+    {
+        return DateTime.ParseExact(csv.GetString(index), "yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+    }
+
+    private static DateOnly? ParseOptionalDate(CsvDataReader csv, int index)
+    {
+        var value = GetOptionalString(csv, index);
+        return value is null
+            ? null
+            : DateOnly.ParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture);
+    }
+
+    private static DateTime? ParseOptionalDateTime(CsvDataReader csv, int index)
+    {
+        var value = GetOptionalString(csv, index);
+        return value is null
+            ? null
+            : DateTime.ParseExact(value, "yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+    }
+
+    private static string? GetOptionalString(CsvDataReader csv, int index)
+    {
+        var value = csv.GetString(index);
+        return string.IsNullOrEmpty(value) ? null : value;
     }
 }


### PR DESCRIPTION
## Summary
- implement streaming NEM13 parsing for 100, 250, 550, and 900 records
- add typed models for accumulation meter data and NEM13 B2B details
- validate header ordering and NEM13 version headers

## Reference
- AEMO MDFF NEM12/NEM13 specification: https://www.aemo.com.au/-/media/Files/Electricity/NEM/Retail_and_Metering/Metering-Procedures/2018/MDFF-Specification-NEM12--NEM13-v106.pdf
