### PR TITLE
chore(package): include readme metadata

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,6 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="FluentValidation" Version="11.9.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Sylvan.Data.Csv" Version="1.3.9" />
     <PackageVersion Include="xunit" Version="2.5.3" />

--- a/src/AEMO.MDFF/AEMO.MDFF.csproj
+++ b/src/AEMO.MDFF/AEMO.MDFF.csproj
@@ -9,6 +9,7 @@
         <Copyright>Copyright © 2024, Akhan Zhakiyanov. All rights reserved.</Copyright>
         <PackageProjectUrl>https://github.com/ahanoff/aemo-mdff-net</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/ahanoff/aemo-mdff-net</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>parsing;aemo;nem12;nem13;meter-reading</PackageTags>
@@ -17,10 +18,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-      <PackageReference Include="Microsoft.Extensions.Options" />
       <PackageReference Include="Sylvan.Data.Csv" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- include README.md in the NuGet package metadata
- remove unused package references from the library project
- remove unused centralized package version entries

## Stack
- stacked on #22 because this updates the centralized package management files introduced there

## Tests
- DOTNET_ROLL_FORWARD=Major dotnet test AEMO.MDFF.sln