### PR TITLE
docs: add AGENTS.md and update contributing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+## Instructions
+
+- Follow `CONTRIBUTING.md` for repository layout, commands, parser guidelines, and PR conventions.
+- Treat `CONTRIBUTING.md` as the source of truth when it conflicts with this file.
+- For automated edits, keep changes narrowly scoped and avoid committing generated `bin`, `obj`, or package output files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,52 @@
-# Contributing guidelines
+# Contributing Guidelines
 
-## Pre-requisites
+## Prerequisites
 
- - [.NET 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- Install the supported .NET SDKs for the target frameworks listed in `Directory.Build.props`.
+- This repository currently targets `net8.0`, `net9.0`, and `net10.0`.
+
+## Repository Layout
+
+- `AEMO.MDFF.sln` is the root solution.
+- Library code lives in `src/AEMO.MDFF`.
+- Tests and sample data live in `src/AEMO.MDFF.Tests`.
+- Shared MSBuild settings live in `Directory.Build.props`.
+- Central NuGet package versions live in `Directory.Packages.props`.
+
+## Build And Test
+
+Run commands from the repository root:
+
+```shell
+dotnet restore AEMO.MDFF.sln
+dotnet build AEMO.MDFF.sln
+dotnet test AEMO.MDFF.sln
+```
+
+If your local machine has a newer .NET runtime but not every older targeted runtime, use:
+
+```shell
+DOTNET_ROLL_FORWARD=Major dotnet test AEMO.MDFF.sln
+```
+
+To validate packaging after a Release build:
+
+```shell
+dotnet build AEMO.MDFF.sln --configuration Release
+dotnet pack AEMO.MDFF.sln --configuration Release --no-build --output nupkgs
+```
+
+## Pull Requests
+
+- Use conventional commits, for example `fix(nem12): ...`, `feat(nem13): ...`, or `chore(build): ...`.
+- Keep each PR focused on one concern where practical.
+- Include tests for parser behavior changes and malformed record ordering.
+- Do not commit generated `bin`, `obj`, or local package output files.
+
+## Parser Guidelines
+
+- Keep MDFF readers streaming: parse one CSV row at a time and yield records incrementally.
+- Avoid parser state that survives across calls to `ReadAsync`.
+- Keep per-record allocations bounded.
+- Model optional MDFF fields as nullable.
+- Use explicit `InvalidDataException` messages for invalid record ordering or unsupported record types.

--- a/src/AEMO.MDFF/AEMO.MDFF.csproj
+++ b/src/AEMO.MDFF/AEMO.MDFF.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.2.1</Version>
+        <Version>0.3.0</Version>
         <Title>AEMO.MDFF</Title>
         <Authors>Akhan Zhakiyanov</Authors>
         <Description>Parser for Australian Energy Market Operator (AEMO) Meter Data File Format (MDFF) specification</Description>


### PR DESCRIPTION
## Summary
- add AGENTS.md that directs agents to CONTRIBUTING.md
- expand CONTRIBUTING.md with root-solution commands, central package management notes, parser guidance, and PR conventions
- bump package version from 0.2.1 to 0.3.0

## Validation
- DOTNET_ROLL_FORWARD=Major dotnet test AEMO.MDFF.sln
- DOTNET_ROLL_FORWARD=Major dotnet pack AEMO.MDFF.sln --configuration Release --output /tmp/aemo-mdff-0.3.0-test
- verified the local nupkg is AEMO.MDFF.0.3.0.nupkg and includes README.md with nuspec <readme>README.md</readme>