### PR TITLE
chore(publish): use latest dotnet sdk

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,10 +14,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: |
-            8.x
-            9.x
-            10.x
+          dotnet-version: '10.x'
           dotnet-quality: 'ga'
 
       - name: Restore dependencies


### PR DESCRIPTION
## Summary
- update the publish workflow to install only the latest supported .NET SDK, currently 10.x
- leave the build workflow validating all supported target frameworks

## Validation
- workflow-only change; checked YAML diff locally